### PR TITLE
Reuse existing styles and keep existing class names

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,8 +40,8 @@ export default function (h) {
     return function (decls) {
       var parsed = parse(decls);
       return function (props, children) {
-        var classes = [props && props.class, parsed].filter(Boolean);
-        return h(tag, Object.assign({}, props, { class: classes.join(' ') }), children);
+        var classes = [props && props.class, parsed].filter(Boolean)
+        return h(tag, Object.assign({}, props, { class: classes.join(' ') }), children)
       }
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ function parse (decls, child, media, className) {
 export default function (h) {
   return function (tag) {
     return function (decls) {
-      var parsed = parse(decls);
+      var parsed = parse(decls)
       return function (props, children) {
         var classes = [props && props.class, parsed].filter(Boolean)
         return h(tag, merge(props, { class: classes.join(' ') }), children)

--- a/src/index.js
+++ b/src/index.js
@@ -54,8 +54,9 @@ export default function (h) {
     return function (decls) {
       var parsed = parse(decls)
       return function (props, children) {
-        var classes = [props && props.class, parsed].filter(Boolean)
-        return h(tag, merge(props, { class: classes.join(' ') }), children)
+        props = props || {}
+        props.class = ((props.class || '') + ' ' + parsed).trim()
+        return h(tag, props, children)
       }
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -38,10 +38,10 @@ function parse (decls, child, media, className) {
 export default function (h) {
   return function (tag) {
     return function (decls) {
-      return function (data, children) {
-        data = data || {}
-        data.class = parse(decls)
-        return h(tag, data, children)
+      const parsed = parse(decls);
+      return function (props, children) {
+        const classes = [props && props.class, parsed].filter(x => x);
+        return h(tag, Object.assign({}, props, { class: classes.join(' ') }), children);
       }
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -39,10 +39,10 @@ export default function (h) {
   return function (tag) {
     return function (decls) {
       var parsed = parse(decls)
-      return function (props, children) {
-        props = props || {}
-        props.class = ((props.class || '') + ' ' + parsed).trim()
-        return h(tag, props, children)
+      return function (data, children) {
+        data = data || {}
+        data.class = ((data.class || '') + ' ' + parsed).trim()
+        return h(tag, data, children)
       }
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -9,20 +9,6 @@ function insert (rule) {
   sheet.insertRule(rule, 0)
 }
 
-function merge(a, b) {
-  var obj = {}
-
-  for (var i in a) {
-    obj[i] = a[i]
-  }
-
-  for (var i in b) {
-    obj[i] = b[i]
-  }
-
-  return obj
-}
-
 function createRule (className, decls, media) {
   var newDecls = []
   for (var property in decls) {

--- a/src/index.js
+++ b/src/index.js
@@ -38,9 +38,9 @@ function parse (decls, child, media, className) {
 export default function (h) {
   return function (tag) {
     return function (decls) {
-      const parsed = parse(decls);
+      var parsed = parse(decls);
       return function (props, children) {
-        const classes = [props && props.class, parsed].filter(x => x);
+        var classes = [props && props.class, parsed].filter(Boolean);
         return h(tag, Object.assign({}, props, { class: classes.join(' ') }), children);
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,20 @@ function insert (rule) {
   sheet.insertRule(rule, 0)
 }
 
+function merge(a, b) {
+  var obj = {}
+
+  for (var i in a) {
+    obj[i] = a[i]
+  }
+
+  for (var i in b) {
+    obj[i] = b[i]
+  }
+
+  return obj
+}
+
 function createRule (className, decls, media) {
   var newDecls = []
   for (var property in decls) {
@@ -41,7 +55,7 @@ export default function (h) {
       var parsed = parse(decls);
       return function (props, children) {
         var classes = [props && props.class, parsed].filter(Boolean)
-        return h(tag, Object.assign({}, props, { class: classes.join(' ') }), children)
+        return h(tag, merge(props, { class: classes.join(' ') }), children)
       }
     }
   }


### PR DESCRIPTION
Hi there. Been playing with this and hyperapp at the weekend and bumped into a couple of issues so thought I would have a go at fixing them :)

This PR introduces 2 small fixes:

1. Makes the sure the style declarations are only parsed once and then reused for each subsequent call.
2. Appends to any existing `class` attrib that was set in `props` instead of overwriting it.

A couple of notes:

1. `parsed` is now being used outside of function scope. Not sure how you feel about that.
2.  I used `Object.assign` to clone the `props` and set the class. This has browser compat issues

I made a quick demo at https://codesandbox.io/s/188x45xr5l

As you change the picostyle lib being used at the top of the file, you can observe the difference in class names displayed after each H1.

Any feedback appreciated!