### PR TITLE
Add jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,9 @@ Then with a module bundler like [Rollup](https://github.com/rollup/rollup) or [W
 import picostyle from "picostyle"
 ```
 
-Otherwise, download the [latest release](https://github.com/picostyle/picostyle/releases/latest) or load directly from [unpkg](https://unpkg.com/picostyle) or [jsDelivr](https://cdn.jsdelivr.net/npm/picostyle@0.1.5/dist/picostyle.js).
+Otherwise, download the [latest release](https://github.com/picostyle/picostyle/releases/latest) or load directly from [unpkg](https://unpkg.com/picostyle) or [jsDelivr](https://cdn.jsdelivr.net/npm/picostyle@latest/dist/picostyle.js).
 ```html
 <script src="https://unpkg.com/picostyle"></script>
-or 
-<script src="https://cdn.jsdelivr.net/npm/picostyle@latest/dist/picostyle.js"></script>
 ```
 
 Then find it in `window.picostyle`.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Otherwise, download the [latest release](https://github.com/picostyle/picostyle/
 ```html
 <script src="https://unpkg.com/picostyle"></script>
 or 
-<script src="https://cdn.jsdelivr.net/npm/picostyle@0.1.5/dist/picostyle.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/picostyle@latest/dist/picostyle.js"></script>
 ```
 
 Then find it in `window.picostyle`.

--- a/README.md
+++ b/README.md
@@ -35,9 +35,11 @@ Then with a module bundler like [Rollup](https://github.com/rollup/rollup) or [W
 import picostyle from "picostyle"
 ```
 
-Otherwise, download the [latest release](https://github.com/picostyle/picostyle/releases/latest) or load directly from [unpkg](https://unpkg.com/picostyle).
+Otherwise, download the [latest release](https://github.com/picostyle/picostyle/releases/latest) or load directly from [unpkg](https://unpkg.com/picostyle) or [jsDelivr](https://cdn.jsdelivr.net/npm/picostyle@0.1.5/dist/picostyle.js).
 ```html
 <script src="https://unpkg.com/picostyle"></script>
+or 
+<script src="https://cdn.jsdelivr.net/npm/picostyle@0.1.5/dist/picostyle.js"></script>
 ```
 
 Then find it in `window.picostyle`.


### PR DESCRIPTION
I added [jsDelivr CDN links](https://www.jsdelivr.com/package/npm/picostyle) to your readme as an alternative to unpkg. jsDelivr is also the [fastest opensource CDN](https://www.cdnperf.com/) available and built specifically for production usage. It can serve any project from npm with zero config just like unpkg.