### PR TITLE
Add test suite and better selector/combinator support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 node_modules
+coverage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Picostyle
 
-[![371 gzip][gzip-badge]][bundlesize]
+[![405 gzip][gzip-badge]][bundlesize]
 [![Build Status][travis-badge]][travis]
 
 [gzip-badge]: https://img.shields.io/badge/minified%20&%20gzipped-371%20B-brightgreen.svg

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 [travis-badge]: https://travis-ci.org/picostyle/picostyle.svg
 [travis]: https://travis-ci.org/picostyle/picostyle
 
-Picostyle is a 0.3 KB CSS-in-JS library for use with frameworks that expose an `h` function.
+Picostyle is a 0.4 KB CSS-in-JS library for use with frameworks that expose an `h` function.
 
 [Try it Online](https://codepen.io/lukejacksonn/pen/xXRGpv?editors=0010)
 
-- **🚀 The smallest CSS-in-JS library**: Only 0.3 KB (minified & gzipped).
-- **👏 Zero dependencies**: And under 60 LOC.
+- **🚀 The smallest CSS-in-JS library**: Only 0.4 KB (minified & gzipped).
+- **👏 Zero dependencies**: And under 70 LOC.
 - **💅 Styled components**: Gives you a styled component like [styled-components](https://www.styled-components.com/) that y'all love.
 
 Currently tested with:

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "size-limit": [
     {
       "path": "dist/picostyle.js",
-      "limit": "399B"
+      "limit": "499B"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -9,14 +9,18 @@
     "build": "npm run clear && rollup -c",
     "clear": "(rm -rf dist || true) && mkdir dist",
     "example": "webpack-dev-server",
-    "format": "prettier --no-semi --write 'src/**/*.js'",
-    "lint": "prettier --no-semi -l 'src/**/*.js'",
+    "format": "prettier --no-semi --write 'src/**/*.js' 'test/**/*.js'",
+    "lint": "prettier --no-semi -l 'src/**/*.js' 'test/**/*.js'",
     "prepublish": "npm run build",
-    "size-check": "npm run build && size-limit"
+    "size-check": "npm run build && size-limit",
+    "test": "jest --coverage --no-cache"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/morishitter/picostyle.git"
+  },
+  "babel": {
+    "presets": "env"
   },
   "keywords": [
     "css",
@@ -31,6 +35,10 @@
   },
   "homepage": "https://github.com/morishitter/picostyle#readme",
   "devDependencies": {
+    "babel-preset-env": "^1.6.1",
+    "jest": "^21.2.1",
+    "jsdom": "^11.4.0",
+    "picodom": "^1.0.2",
     "prettier": "^1.7.0",
     "rollup": "^0.47.5",
     "rollup-plugin-uglify": "^2.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -12,10 +12,19 @@ function insert(rule) {
 function createRule(className, decls, media) {
   var newDecls = []
   for (var property in decls) {
-    newDecls.push(hyphenate(property) + ":" + decls[property] + ";")
+    typeof decls[property] !== "object" &&
+      newDecls.push(hyphenate(property) + ":" + decls[property] + ";")
   }
   var rule = "." + className + "{" + newDecls.join("") + "}"
   return media ? media + "{" + rule + "}" : rule
+}
+
+function concat(str1, str2) {
+  if (/^[a-z]/.test(str2)) {
+    return str1 + " " + str2
+  } else {
+    return str1 + str2
+  }
 }
 
 function parse(decls, child, media, className) {
@@ -26,12 +35,12 @@ function parse(decls, child, media, className) {
     var value = decls[property]
     if (typeof value === "object") {
       var nextMedia = /^@/.test(property) ? property : null
-      var nextChild = nextMedia ? child : child + property
+      var nextChild = nextMedia ? child : concat(child, property)
       parse(value, nextChild, nextMedia, className)
     }
   }
 
-  insert(createRule(className + child, decls, media))
+  insert(createRule(concat(className, child), decls, media))
   return className
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,11 +20,7 @@ function createRule(className, decls, media) {
 }
 
 function concat(str1, str2) {
-  if (/^[a-z]/.test(str2)) {
-    return str1 + " " + str2
-  } else {
-    return str1 + str2
-  }
+  return str1 + (/^\w/.test(str2) ? " " : "") + str2
 }
 
 function parse(decls, child, media, className) {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -20,7 +20,7 @@ function removeRules(stylesheet) {
   }
 }
 
-function expectClassNameAndProps(obj, className, cssAsText) {
+function expectClassNameAndCssText(obj, className, cssAsText) {
   expect(obj.props).toHaveProperty("class", className)
   expect(cssRulesAsText(document.styleSheets[0])).toEqual(cssAsText)
 }
@@ -32,14 +32,14 @@ afterEach(() => {
 
 test("empty style object", () => {
   const Test = style("div")
-  expectClassNameAndProps(Test(), "p0", ".p0 {}")
+  expectClassNameAndCssText(Test(), "p0", ".p0 {}")
 })
 
 test("basic style object", () => {
   const Test = style("div", {
     color: "red"
   })
-  expectClassNameAndProps(Test(), "p1", ".p1 {color: red;}")
+  expectClassNameAndCssText(Test(), "p1", ".p1 {color: red;}")
 })
 
 test("1 level descendant combinator", () => {
@@ -49,7 +49,7 @@ test("1 level descendant combinator", () => {
       color: "white"
     }
   })
-  expectClassNameAndProps(
+  expectClassNameAndCssText(
     Test(),
     "p2",
     ".p2 {color: red;},.p2 tr {color: white;}"
@@ -66,7 +66,7 @@ test("2 level descendant combinator", () => {
       }
     }
   })
-  expectClassNameAndProps(
+  expectClassNameAndCssText(
     Test(),
     "p3",
     ".p3 {color: red;},.p3 tr {color: white;},.p3 tr td {color: blue;}"
@@ -79,7 +79,7 @@ test("class selector", () => {
       color: "white"
     }
   })
-  expectClassNameAndProps(Test(), "p4", ".p4 {},.p4.active {color: white;}")
+  expectClassNameAndCssText(Test(), "p4", ".p4 {},.p4.active {color: white;}")
 })
 
 test("universal selector (asterisk)", () => {
@@ -88,7 +88,7 @@ test("universal selector (asterisk)", () => {
       color: "white"
     }
   })
-  expectClassNameAndProps(Test(), "p5", ".p5 {},.p5* {color: white;}")
+  expectClassNameAndCssText(Test(), "p5", ".p5 {},.p5* {color: white;}")
 })
 
 test("pseudo-element", () => {
@@ -97,7 +97,7 @@ test("pseudo-element", () => {
       content: "attr(data-value) '%'"
     }
   })
-  expectClassNameAndProps(
+  expectClassNameAndCssText(
     Test(),
     "p6",
     ".p6 {},.p6::before {content: attr(data-value) '%';}"
@@ -110,7 +110,7 @@ test("pseudo-class", () => {
       color: "white"
     }
   })
-  expectClassNameAndProps(Test(), "p7", ".p7 {},.p7:hover {color: white;}")
+  expectClassNameAndCssText(Test(), "p7", ".p7 {},.p7:hover {color: white;}")
 })
 
 test("pseudo-class", () => {
@@ -119,7 +119,7 @@ test("pseudo-class", () => {
       width: "auto"
     }
   })
-  expectClassNameAndProps(
+  expectClassNameAndCssText(
     Test(),
     "p8",
     ".p8 {},@media screen and (min-width: 480px) {.p8 {width: auto;}}"
@@ -135,7 +135,7 @@ test("class name bundling", () => {
   })
 
   // BUG: Fix this test when https://github.com/picostyle/picostyle/pull/26 is resolved
-  expectClassNameAndProps(
+  expectClassNameAndCssText(
     Test(),
     "p9 p9 pa",
     ".pa {background-color: red;},.p9 {color: white;}"
@@ -146,7 +146,7 @@ test("decl as function", () => {
   const Test = style("div", props => {
     return { color: props.color }
   })
-  expectClassNameAndProps(
+  expectClassNameAndCssText(
     Test({ color: "tomato" }),
     "pb",
     ".pb {color: tomato;}"
@@ -158,5 +158,5 @@ test("extend component", () => {
   const Test = style(Div, {
     backgroundColor: "red"
   })
-  expectClassNameAndProps(Test({}), "pc", ".pc {background-color: red;}")
+  expectClassNameAndCssText(Test({}), "pc", ".pc {background-color: red;}")
 })

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -134,7 +134,7 @@ test("class name bundling", () => {
     backgroundColor: "red"
   })
 
-  // BUG: See https://github.com/picostyle/picostyle/pull/26
+  // BUG: Fix this test when https://github.com/picostyle/picostyle/pull/26 is resolved
   expectClassNameAndProps(
     Test(),
     "p9 p9 pa",

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,0 +1,162 @@
+import { h } from "picodom"
+import picostyle from "../src"
+
+// import create and attach a dom to global namespace
+import { JSDOM } from "jsdom"
+
+const dom = new JSDOM()
+global.document = dom.window.document
+
+// picostyle helper function
+const style = (type, decls) => picostyle(h)(type)(decls)
+
+function cssRulesAsText(stylesheet) {
+  return stylesheet.cssRules.map(rule => rule.cssText).join()
+}
+
+function removeRules(stylesheet) {
+  while (stylesheet.cssRules.length) {
+    stylesheet.deleteRule(0)
+  }
+}
+
+function expectClassNameAndProps(obj, className, cssAsText) {
+  expect(obj.props).toHaveProperty("class", className)
+  expect(cssRulesAsText(document.styleSheets[0])).toEqual(cssAsText)
+}
+
+afterEach(() => {
+  removeRules(document.styleSheets[0])
+  document.body.innerHTML = ""
+})
+
+test("empty style object", () => {
+  const Test = style("div")
+  expectClassNameAndProps(Test(), "p0", ".p0 {}")
+})
+
+test("basic style object", () => {
+  const Test = style("div", {
+    color: "red"
+  })
+  expectClassNameAndProps(Test(), "p1", ".p1 {color: red;}")
+})
+
+test("1 level descendant combinator", () => {
+  const Test = style("table", {
+    color: "red",
+    tr: {
+      color: "white"
+    }
+  })
+  expectClassNameAndProps(
+    Test(),
+    "p2",
+    ".p2 {color: red;},.p2 tr {color: white;}"
+  )
+})
+
+test("2 level descendant combinator", () => {
+  const Test = style("table", {
+    color: "red",
+    tr: {
+      color: "white",
+      td: {
+        color: "blue"
+      }
+    }
+  })
+  expectClassNameAndProps(
+    Test(),
+    "p3",
+    ".p3 {color: red;},.p3 tr {color: white;},.p3 tr td {color: blue;}"
+  )
+})
+
+test("class selector", () => {
+  const Test = style("div", {
+    ".active": {
+      color: "white"
+    }
+  })
+  expectClassNameAndProps(Test(), "p4", ".p4 {},.p4.active {color: white;}")
+})
+
+test("universal selector (asterisk)", () => {
+  const Test = style("div", {
+    "*": {
+      color: "white"
+    }
+  })
+  expectClassNameAndProps(Test(), "p5", ".p5 {},.p5* {color: white;}")
+})
+
+test("pseudo-element", () => {
+  const Test = style("div", {
+    "::before": {
+      content: "attr(data-value) '%'"
+    }
+  })
+  expectClassNameAndProps(
+    Test(),
+    "p6",
+    ".p6 {},.p6::before {content: attr(data-value) '%';}"
+  )
+})
+
+test("pseudo-class", () => {
+  const Test = style("div", {
+    ":hover": {
+      color: "white"
+    }
+  })
+  expectClassNameAndProps(Test(), "p7", ".p7 {},.p7:hover {color: white;}")
+})
+
+test("pseudo-class", () => {
+  const Test = style("div", {
+    "@media screen and (min-width: 480px)": {
+      width: "auto"
+    }
+  })
+  expectClassNameAndProps(
+    Test(),
+    "p8",
+    ".p8 {},@media screen and (min-width: 480px) {.p8 {width: auto;}}"
+  )
+})
+
+test("class name bundling", () => {
+  const Div = style("div", {
+    color: "white"
+  })
+  const Test = style(Div, {
+    backgroundColor: "red"
+  })
+
+  // BUG: See https://github.com/picostyle/picostyle/pull/26
+  expectClassNameAndProps(
+    Test(),
+    "p9 p9 pa",
+    ".pa {background-color: red;},.p9 {color: white;}"
+  )
+})
+
+test("decl as function", () => {
+  const Test = style("div", props => {
+    return { color: props.color }
+  })
+  expectClassNameAndProps(
+    Test({ color: "tomato" }),
+    "pb",
+    ".pb {color: tomato;}"
+  )
+})
+
+test("extend component", () => {
+  const Div = (props, children) => h("div", props, children)
+  const Test = style(Div, {
+    backgroundColor: "red"
+  })
+  expectClassNameAndProps(Test({}), "pc", ".pc {background-color: red;}")
+})


### PR DESCRIPTION
A few items in this PR:

1. Notably, a test suite with 100% coverage :) Codecov and Travis testing can be added later if desired.
2. Support for both selectors and combinators in the decls, for example:
```
{
  color: 'red',
  td: {
    '*': {
      color: 'white'
  }
}
```
3. Fixed minor issue with nested object styles appearing as `[Object]` in the CSS

NOTE 1:  All tests pass, even if they are not necessarily producing the desired output. There are bugs which I can report/address after this PR.

NOTE 2: The tests are super fragile due to the global `_id` variable being incremented each time. This probably needs refactoring.  You cannot only run one or two tests at a time, it will fail due to the undeterminable value of `_id`.

NOTE 3: It's not currently possible to hook into and test the CSS text that is being generated *before* it ends up in the DOM. Therefore we have to use `jsdom` to retrieve the CSS rules afte the fact and make comparisons there. Improvements can be made here too.