### PR TITLE
Memoize component based on passed in props.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 var _id = 0
 var sheet = document.head.appendChild(document.createElement("style")).sheet
+var serialize = JSON.stringify.bind(null)
 
 function hyphenate(str) {
   return str.replace(/[A-Z]/g, "-$&").toLowerCase()
@@ -42,20 +43,18 @@ function parse(decls, child, media, className) {
 
 export default function(h) {
   return function(type) {
+    var cache = {}
     return function(decls) {
-      var parsed
       var isDeclsFunction = typeof decls === "function"
-      !isDeclsFunction && (parsed = parse(decls))
+
       return function(props, children) {
         props = props || {}
-        isDeclsFunction && (parsed = parse(decls(props)))
+        var key = serialize(props)
+        cache[key] ||
+          (cache[key] =
+            (isDeclsFunction && parse(decls(props))) || parse(decls))
         var node = h(type, props, children)
-        node.props.class = ((node.props.class || "") +
-          " " +
-          (props.class || "") +
-          " " +
-          parsed
-        ).trim()
+        node.props.class = [props.class, cache[key]].filter(Boolean).join(" ")
         return node
       }
     }


### PR DESCRIPTION
Prevent new classes from being inserted into the sheet when a styled component is generated with the same passed props.

Not a perfect solution as what could also be done is having `children` and `type` hashed in some way to the memo cache to alternatively update the components classes styles when its underlying CSS is modified in realtime.

As of right now, when the underlying styles for the components is modified in realtime, a new class is unfortunately assigned.

Regardless, in Hyperapp, the changes solve the issue of new classes being generated when no state is changed. See https://github.com/hyperapp/hyperapp/issues/553