### PR TITLE
Do not overwrite class

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ export default function(h) {
           (cache[key] =
             (isDeclsFunction && parse(decls(props))) || parse(decls))
         var node = h(type, props, children)
-        node.props.class = [props.class, cache[key]].filter(Boolean).join(" ")
+        node.props.class = [props.class, cache[key], node.props.class].filter(Boolean).join(" ")
         return node
       }
     }


### PR DESCRIPTION
Previously, the node class name was overwritten by picostyle.

This MR appends classes instead of overwriting them